### PR TITLE
add error handling in escape function

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var debounce = require('debounce');
 var _ = document.querySelector.bind(document);
 
 function escape(str) {
-  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\"/g, '&quot;');
+  return (str.length) ? str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\"/g, '&quot;') : '';
 }
 function hide(selector) {
   var elements = document.querySelectorAll(selector);


### PR DESCRIPTION
The escape function was throwing errors when there were optional params in the route definition but not in the URL path. Added error handling for this case